### PR TITLE
Add GetAvailableLanguages and GetCurrentLanguage to release note

### DIFF
--- a/Docs/releases/release-3.2.3.md
+++ b/Docs/releases/release-3.2.3.md
@@ -16,3 +16,6 @@ Adds "interaction passthrough" to the World Descriptor and fixes a bug in the Av
 * Added a mask for "interaction passthrough" in the WorldDescriptor, so that world creators can allow interaction and grabs to occur through user defined layers. By default (Nothing) they will use the legacy behaviour, which was to always block interactions and grabs.
   * Note: This does not change the normal Unity behaviour that if a ray begins inside a collider, it ignores that collider. This means that desktop (which begins its ray from the center of the Player Capsule) will behave differently than VR, where the tracked hand can enter colliders that the Player Capsule cannot.
 * Updates the Avatar Scaling Example Graph to prevent errors when running without ClientSim or when building the world.
+
+## Features
+* Adds `VRCPlayerApi.GetAvailableLanguages()` and `VRCPlayerApi.GetCurrentLanguage()`

--- a/Docs/releases/release-3.2.3.md
+++ b/Docs/releases/release-3.2.3.md
@@ -1,0 +1,18 @@
+---
+slug: release-3-2-3
+date: 2023-08-09
+title: Release 3.2.3
+authors: [momo]
+tags: [release]
+draft: false
+---
+### Summary
+
+Adds "interaction passthrough" to the World Descriptor and fixes a bug in the Avatar Scaling Example Graph.
+
+<!--truncate-->
+
+### Changes
+* Added a mask for "interaction passthrough" in the WorldDescriptor, so that world creators can allow interaction and grabs to occur through user defined layers. By default (Nothing) they will use the legacy behaviour, which was to always block interactions and grabs.
+  * Note: This does not change the normal Unity behaviour that if a ray begins inside a collider, it ignores that collider. This means that desktop (which begins its ray from the center of the Player Capsule) will behave differently than VR, where the tracked hand can enter colliders that the Player Capsule cannot.
+* Updates the Avatar Scaling Example Graph to prevent errors when running without ClientSim or when building the world.


### PR DESCRIPTION
In addition, release-3.2.3.md is added with exactly same contents as https://creators.vrchat.com/releases/release-3-2-3 except for GetAvailableLanguages and GetCurrentLanguage addition.

P.S. Since interaction passthrough, GetAvailableLanguages, and GetCurrentLanguage are new features, VRCSDK should release it as 3.3.0 when VRCSDK follow semantic versioning.