### PR TITLE
Updated directions to example prefabs

### DIFF
--- a/Docs/docs/worlds/sdk-prefabs.md
+++ b/Docs/docs/worlds/sdk-prefabs.md
@@ -10,34 +10,34 @@ This is a list of prefabs available in our SDKs!
 ## VRCAvatarPedestal
 An example of how to create an avatar pedestal that you click on to wear a new avatar using Udon.
 
-Found in `VRChat Examples > Prefabs > AvatarPedestal`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > AvatarPedestal`.
 
 ## VRCChair
 An example of how to create a chair that you click on to sit in using Udon.
 
-Found in `VRChat Examples > Prefabs > VRCChair`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > VRCChair > VRCChair3`.
 
 ## VRCMirror
 An example of how to create the ever-popular Mirror using Udon.
 
-Found in `VRChat Examples > Prefabs > VRCMirror`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > VRCMirror`.
 
 ## VRCPortalMarker
 An example of how to use [VRC_PortalMarker](/worlds/components/vrc_portalmarker).
 
-Found in `VRChat Examples > Prefabs > VRCPortalMarker`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > VRCPortalMarker`.
 
 This prefab **must** be at the root of your scene hierarchy for the portal's destination instance to be synced with other players.
 
 ## VRCWorld
 An example of how to use [VRC_SceneDescriptor](/worlds/components/vrc_scenedescriptor) to define a VRChat World.
 
-Found in  `VRChat examples > Prefabs > World`.
+Found in  `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > World`.
 
 ## VRCVideoSync
 An example of how to create an Udon-powered [Video Player](/worlds/udon/video-players/). 
 
-Found in `VRChat Examples > Prefabs > Video Players`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > VideoPlayers`.
 
 Two examples exist:
 - `UdonSyncPlayer (AVPro).prefab` - Uses AVPro, which permits watching livestreams.
@@ -48,9 +48,9 @@ An example of how to create an Udon-powered pen for drawing in 3D space!
 
 Documented here: [Simple Pen System](/worlds/examples/udon-example-scene/simple-pen-system)
 
-Found in `VRChat Examples > Prefabs > SimplePenSystem`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > SimplePenSystem`.
 
 ## Udon Variable Sync
 A self-documenting example on how Udon Variable Sync works! Drop it into your world and test it out to see how it works.
 
-Found in `VRChat Examples > Prefabs > Udon Variable Sync`.
+Found in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs > Udon Variable Sync`.


### PR DESCRIPTION
In a freshly created project the locations previously listed (`VRChat Examples > Prefabs`) simply doesn't exist anymore.
All of the prefabs in new projects are instead now located in `Packages > VRChat SDK - Worlds > Samples > UdonExampleScene > Prefabs`.