### PR TITLE
fix public sdk location

### DIFF
--- a/Docs/docs/sdk/public-sdk-api.md
+++ b/Docs/docs/sdk/public-sdk-api.md
@@ -16,11 +16,13 @@ For worlds: `Packages/VRChat SDK - Worlds > Editor/VRCSDK/SDK3/Public SDK API`
 However, most of the events and methods are shared between both the world and avatar SDKs and are defined in the **Base SDK Package**: `Packages/VRChat SDK - Base > Editor/VRCSDK/Dependencies/VRChat/Public SDK API`.
 
 :::note
+
 These types are in assembly definitions that are auto referenced. If you are writing code in your own project, the types will usually be available by default. If you're writing a redistributable package and have your own assembly definition, you will need to add the appropriate assembly definition references:
 
 For avatars: `VRC.SDK3A.Editor`  
 For worlds: `VRC.SDK3.Editor`  
 For both: `VRC.SDKBase.Editor`
+
 :::
 # What's available?
 

--- a/Docs/docs/sdk/public-sdk-api.md
+++ b/Docs/docs/sdk/public-sdk-api.md
@@ -3,18 +3,25 @@ title: "Public SDK API"
 slug: "public-sdk-api"
 hidden: false
 createdAt: "2023-08-18T21:01:07.855Z"
-updatedAt: "2023-08-18T21:04:48.137Z"
+updatedAt: "2023-09-18T03:02:02.524Z"
 ---
 
 The VRChat SDK provides a set of interfaces and methods you can use to enhance your world and avatar build process. 
 
 You can find the **Public SDK API** folder in both SDKs:
 
-For avatars: `Packages/VRChat SDK > Avatars/Editor/VRCSDK/SDK3A/Public SDK API`  
-For worlds: `Packages/VRChat SDK > Base/Editor/VRCSDK/SDK3A/Public SDK API`
+For avatars: `Packages/VRChat SDK - Avatars > Editor/VRCSDK/SDK3A/Public SDK API`  
+For worlds: `Packages/VRChat SDK - Worlds > Editor/VRCSDK/SDK3/Public SDK API`
 
-However, most of the events and methods are shared between both the world and avatar SDKs and are defined in the **Base SDK Package.**
+However, most of the events and methods are shared between both the world and avatar SDKs and are defined in the **Base SDK Package**: `Packages/VRChat SDK - Base > Editor/VRCSDK/Dependencies/VRChat/Public SDK API`.
 
+:::note
+These types are in assembly definitions that are auto referenced. If you are writing code in your own project, the types will usually be available by default. If you're writing a redistributable package and have your own assembly definition, you will need to add the appropriate assembly definition references:
+
+For avatars: `VRC.SDK3A.Editor`  
+For worlds: `VRC.SDK3.Editor`  
+For both: `VRC.SDKBase.Editor`
+:::
 # What's available?
 
 For the most up-to-date list of events and methods, we recommend looking at the files directly mentioned above.


### PR DESCRIPTION
The current documentation gives only two out of three of the relevant paths, and they are incorrect.

This PR also adds a note about how to use the types in your own assembly definition.