### PR TITLE
Correction of typos in method names

### DIFF
--- a/Docs/docs/worlds/udon/data-containers/vrcjson.md
+++ b/Docs/docs/worlds/udon/data-containers/vrcjson.md
@@ -24,13 +24,13 @@ Note that in Udon Graph, "VRC" is removed from the beginning of all class names,
 
 JSON is a small, simple, and strict specification. DataLists and DataDictionaries are capable of supporting a much wider range of configurations, which means that you may face some limitations when going from Data container to JSON. Make sure you are aware of these limitations and avoid using these configurations in situations where you intend to use JSON.
 
-**JSON does not support `Object Reference` Data Tokens.** If you have any object references in your Data containers when you try to serialize to JSON, the SerializeToJson function will return false with `DataError.TypeUnsupported`
+**JSON does not support `Object Reference` Data Tokens.** If you have any object references in your Data containers when you try to serialize to JSON, the TrySerializeToJson function will return false with `DataError.TypeUnsupported`
 
-**JSON only supports string-keyed dictionaries.** If you have any keys in your DataDictionaries that are not strings when you try to serialize to JSON, the SerializeToJson function will return false with `DataError.TypeUnsupported`.
+**JSON only supports string-keyed dictionaries.** If you have any keys in your DataDictionaries that are not strings when you try to serialize to JSON, the TrySerializeToJson function will return false with `DataError.TypeUnsupported`.
 
-**JSON does not support NaN or Infinity.** If you have any floats or doubles that contain NaN or Infinity, the SerializeToJson function will return false with `DataError.ValueUnsupported`.
+**JSON does not support NaN or Infinity.** If you have any floats or doubles that contain NaN or Infinity, the TrySerializeToJson function will return false with `DataError.ValueUnsupported`.
 
-**JSON does not support anything other than Dictionary or List as the root.** If you use a simple value DataToken without any children, the SerializeToJson function will return false with `DataError.TypeUnsupported`.
+**JSON does not support anything other than Dictionary or List as the root.** If you use a simple value DataToken without any children, the TrySerializeToJson function will return false with `DataError.TypeUnsupported`.
 
 **JSON only supports one type of number.** It does not differentiate between all the different types. As a result, deserializing from JSON will store all numbers in `Double` format. If you have Data Tokens containing other types of numbers such as `int`, `byte`, or `float` then they can serialize to JSON, however if you Deserialize that same JSON back into Data Containers, you will find that they are now `Doubles` instead.
 
@@ -42,10 +42,10 @@ If TryDeserializeFromJson returns true, then that means it has successfully turn
 
 If this returns false, then the string you provided was not valid JSON. The DataToken you are given will be a DataError, and if you run DataToken.ToString on it, it will give you both the error and a string explaining more details about exactly what went wrong.
 
-For performance reasons, VRCJSON does not parse everything immediately. Instead, it only parses the top level of JSON first. if the top level is valid, but you have have invalid JSON further down inside a nested structure, it is possible for the initial DeserializeFromJson to return true. Later, if you use TryGetValue to pull values from something that was invalid, it will return false and give you DataError.UnableToParse.
+For performance reasons, VRCJSON does not parse everything immediately. Instead, it only parses the top level of JSON first. if the top level is valid, but you have have invalid JSON further down inside a nested structure, it is possible for the initial TryDeserializeFromJson to return true. Later, if you use TryGetValue to pull values from something that was invalid, it will return false and give you DataError.UnableToParse.
 
 ```csharp title="Deserializing from JSON"
-if (VRCJson.DeserializeFromJson(json, out DataToken result))
+if (VRCJson.TryDeserializeFromJson(json, out DataToken result))
 {
     // Deserialization succeeded! Let's figure out what we've got.
     if (result.TokenType == TokenType.DataDictionary)
@@ -58,7 +58,7 @@ if (VRCJson.DeserializeFromJson(json, out DataToken result))
     }
     else 
     {
-        // This should not be possible. If DeserializeFromJson returns true, this it *must* be either a dictionary or a list.
+        // This should not be possible. If TryDeserializeFromJson returns true, this it *must* be either a dictionary or a list.
     }
 } else {
     // Deserialization failed. Let's see what the error was.
@@ -73,7 +73,7 @@ if (VRCJson.DeserializeFromJson(json, out DataToken result))
 If TrySerializeToJson returns true, then that means it has successfully converted your DataList or DataDictionary into a Json string, and you can safely pull the string out of the result token.
 
 ```csharp title="Serializing to JSON"
-if (VRCJson.SerializeToJson(dictionary, JsonExportType.Beautify, out DataToken json))
+if (VRCJson.TrySerializeToJson(dictionary, JsonExportType.Beautify, out DataToken json))
 {
     // Successfully serialized! We can immediately get the string out of the token and do something with it.
     Debug.Log($"Successfully serialized to json: {json.String}");


### PR DESCRIPTION
The following method names are often incorrect in the documentation
VRCJson.TryDeserializeFromJson
VRCJson.TrySerializeToJson