### PR TITLE
add about VRCImposterSettings

### DIFF
--- a/Docs/releases/release-3.3.0.md
+++ b/Docs/releases/release-3.3.0.md
@@ -23,6 +23,8 @@ This update also adds support for the new 'Maximum capacity' and 'Recommended ca
 * Standardized public API has been added for tool developers
 * Content Manager now marks the currently selected world and allows quickly setting any uploaded world as current
 * Countless bug fixes and improvements across Worlds and Avatars SDKs
+* Adds the [VRC Impostor Settings](/avatars/avatar-impostors#vrcimpostorsettings) component to the avatars SDK.
+  * However, you cannot attach this component manually for now.
 
 ### Important note for Tool Developers
 

--- a/Docs/releases/release-3.5.0.md
+++ b/Docs/releases/release-3.5.0.md
@@ -26,6 +26,7 @@ You will need to update your Creator Companion to version 2.2.0 in order to mana
 * Switches from .NET Framework 4.x to .NET Standard 2.1.
 * Restores UdonSharp Samples, now  listed under World Samples.
 * Restores UdonSharp and ClientSim legacyFiles.
+* Now you can add `VRC Imposter Settings` Component!
 
 ## Known Issues
 

--- a/Docs/releases/release-3.5.0.md
+++ b/Docs/releases/release-3.5.0.md
@@ -26,7 +26,7 @@ You will need to update your Creator Companion to version 2.2.0 in order to mana
 * Switches from .NET Framework 4.x to .NET Standard 2.1.
 * Restores UdonSharp Samples, now  listed under World Samples.
 * Restores UdonSharp and ClientSim legacyFiles.
-* Now you can add `VRC Imposter Settings` Component!
+* Now you can add [VRC Impostor Settings](/avatars/avatar-impostors#vrcimpostorsettings) Component!
 
 ## Known Issues
 


### PR DESCRIPTION
In previous versions of VRCSDK, with `AddComponentMenu`, we cannot add component `VRCImposterSettings`