### PR TITLE
Helpful Tip for setting Reflect Layers, added note for Environment Layer.

### DIFF
--- a/Docs/docs/worlds/components/vrc_mirrorreflection.md
+++ b/Docs/docs/worlds/components/vrc_mirrorreflection.md
@@ -26,16 +26,8 @@ Mirrors can drastically reduce the framerate of your VRChat world. To avoid this
 - Don't reflect every layer, or allow users to choose which layers to reflect. ("High quality" and "low quality" mirrors.)
 - If your users still experience performance issue, reduce the mirror resolution.
 
-:::caution Required Layers
-The VRChat Community recommends the following Layers to always be used in Mirrors, as these two show both yourself and other players in the Mirror:
+:::tip
+Having the least amount of Reflect Layers set on a Mirror is recommended, as anything shown in Mirrors are rendered twice.
 
-- `Player`
-- `MirrorReflection`
-
-:::
-
-It is up to your discretion if you want to show the `Default` Layer as well, if you want to reflect the surrounding World environment. **However, this can cost performance.**
-
-:::danger Use only a minimal amount of Reflect Layers!
-Proper filtering of the Reflect Layers will ensure unnecessary graphics such as the HUD, Name Tags, or the Quick Menu, will never appear in Mirrors. If they are shown, it can heavily cost performance.
+For a minimal layer setup, `MirrorReflection` is required to see the local player, and `Player` is required to see other players. Any other layers should be considered based on how your world is set up and what you want to be visible in the mirror, such as pickups and the environment. To learn more about what each Reflect Layer is used for, see [Unity Layers in VRChat](../layers.md).
 :::

--- a/Docs/docs/worlds/components/vrc_mirrorreflection.md
+++ b/Docs/docs/worlds/components/vrc_mirrorreflection.md
@@ -36,8 +36,6 @@ The VRChat Community recommends the following Layers to always be used in Mirror
 
 It is up to your discretion if you want to show the `Default` Layer as well, if you want to reflect the surrounding World environment. **However, this can cost performance.**
 
-:::danger
-To ensure optimal performance, use only a minimal amount of Reflect Layers!
-
-Proper filtering of the Reflect Layers will ensure unnecessary graphics such as the HUD, Name Tags, or the Quick Menu, will never appear in Mirrors, which will heavily cost performance.
+:::danger Use only a minimal amount of Reflect Layers!
+Proper filtering of the Reflect Layers will ensure unnecessary graphics such as the HUD, Name Tags, or the Quick Menu, will never appear in Mirrors. If they are shown, it can heavily cost performance.
 :::

--- a/Docs/docs/worlds/components/vrc_mirrorreflection.md
+++ b/Docs/docs/worlds/components/vrc_mirrorreflection.md
@@ -13,7 +13,7 @@ It requires a [mesh renderer component](https://docs.unity3d.com/Manual/class-Me
 | --- | --- |
 | Disable Pixel Lights | Disables real-time pixel shaded point and spot lighting. Pixel shaded lights will fall-back to vertex lighting when this is enabled. |
 | Turn Off Mirror Occlusion | Disables occlusion culling on the mirror. Enable this if you see objects flickering in the mirror. |
-| Reflect Layers | Only objects on the selected layers will be rendered in the mirror. Objects on the Water layer are never rendered in mirrors. |
+| Reflect Layers | Only objects on the selected layers will be rendered in the mirror. <br />⚠ Objects on the `Water` layer are never rendered in mirrors. |
 | Mirror Resolution | Rendering resolution of the mirror (per eye in VR). Auto renders at the same resolution as the user's HMD or monitor up to the maximum of 2048x2048. |
 | Maximum Antialiasing | The maximum level of MSAA applied to the image rendered in the mirror. Can be overruled by client graphics settings. |
 | Custom Shader | The mirror will use this shader instead of the default shader if one is provided. |
@@ -25,3 +25,16 @@ Mirrors can drastically reduce the framerate of your VRChat world. To avoid this
 - Keep mirrors off by default. Enable them automatically when users get near, or allow users to enable them manually.
 - Don't reflect every layer, or allow users to choose which layers to reflect. ("High quality" and "low quality" mirrors.)
 - If your users still experience performance issue, reduce the mirror resolution.
+
+:::tip
+The VRChat Community recommends using ONLY these `Reflect Layers` on a Mirror:
+
+- `Default`: Shows the surrounding Environment in the World you are in.
+    - *You can ignore this Layer if you want.*
+- `Player`: Shows remote players in the Mirror.
+- `MirrorReflection`: Shows the local player in the Mirror.
+
+All other Layers besides the ones mentioned above should be ignored for optimal performance!
+
+Proper filtering of the Reflect Layers will ensure unnecessary graphics such as the HUD, Name Tags, or the Quick Menu, will never appear in Mirrors, which will heavily cost performance.
+:::

--- a/Docs/docs/worlds/components/vrc_mirrorreflection.md
+++ b/Docs/docs/worlds/components/vrc_mirrorreflection.md
@@ -26,15 +26,18 @@ Mirrors can drastically reduce the framerate of your VRChat world. To avoid this
 - Don't reflect every layer, or allow users to choose which layers to reflect. ("High quality" and "low quality" mirrors.)
 - If your users still experience performance issue, reduce the mirror resolution.
 
-:::tip
-The VRChat Community recommends using ONLY these `Reflect Layers` on a Mirror:
+:::caution Required Layers
+The VRChat Community recommends the following Layers to always be used in Mirrors, as these two show both yourself and other players in the Mirror:
 
-- `Default`: Shows the surrounding Environment in the World you are in.
-    - *You can ignore this Layer if you want.*
-- `Player`: Shows remote players in the Mirror.
-- `MirrorReflection`: Shows the local player in the Mirror.
+- `Player`
+- `MirrorReflection`
 
-All other Layers besides the ones mentioned above should be ignored for optimal performance!
+:::
+
+It is up to your discretion if you want to show the `Default` Layer as well, if you want to reflect the surrounding World environment. **However, this can cost performance.**
+
+:::danger
+To ensure optimal performance, use only a minimal amount of Reflect Layers!
 
 Proper filtering of the Reflect Layers will ensure unnecessary graphics such as the HUD, Name Tags, or the Quick Menu, will never appear in Mirrors, which will heavily cost performance.
 :::

--- a/Docs/docs/worlds/components/vrc_uishape.md
+++ b/Docs/docs/worlds/components/vrc_uishape.md
@@ -1,6 +1,6 @@
 # VRC Ui Shape
 
-Thic component allows players to interact with Unity's UI in your VRChat world. It requires a Unity [UICanvas](https://docs.unity3d.com/Manual/UICanvas.html) element on the same GameObject.
+This component allows players to interact with Unity's UI in your VRChat world. It requires a Unity [UICanvas](https://docs.unity3d.com/Manual/UICanvas.html) element on the same GameObject.
 
 It only has a single parameter:
 

--- a/Docs/docs/worlds/layers.md
+++ b/Docs/docs/worlds/layers.md
@@ -12,20 +12,20 @@ updatedAt: "2023-04-24T16:23:07.971Z"
 
 When you create a Unity project with VRChat's Worlds SDK, your project will automatically be configured to use VRChat's built-in layers. If you change the collision matrix, rename, or remove built-in layers, your changes will be overridden when you upload your world to VRChat.
 
-- Layers 0-7 are 'Builtin' Unity layers.
-- Layers 3, 6, and 7 are internal Unity layers. They cannot be used.
-- Layers 8-21 are 'User' Unity layers managed by VRChat's SDK.
-- Layers 22-31 are unused 'User' Unity layers. You can edit them freely, and changes to these layers will not be discarded when you build & upload your world.
+Layers 22-31 are unused 'User' Unity layers. You can edit them freely, and changes to these layers will not be discarded when you build & upload your world.
 
 ## Unity's built-in layers
 
 | Layer number | Layer Name          | Description  |
-| :-- | :-- | :-- |
+|:-------------|:--------------------| :-- |
 | 0            | Default             | Used for Unity's Game Objects by default. Used by VRChat's Avatar Pedestals.                                                                                                                                                                                         |
 | 1            | TransparentFX       | Used for Unity's Flare Assets.                                                                                                                                                                                                                                       |
 | 2            | IgnoreRaycast       | Ignored by Unity's Physics Raycasts if no layer mask is provided. Not ignored by VRChat's Physics Raycasts.                                                                                                                                                         |
+| 3            | reserved3           | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                          |
 | 4            | Water               | Used by Unity's Standard Assets. Used by VRChat's Portals. Used by VRChat's Mirrors. Often used for Unity's Post Processing.                                                                                                                                          |
 | 5            | UI                  | ⚠ You may not want to use this layer. Used by Unity's UI by default. Ignored by VRChat's UI pointer unless the player has the VRChat menu open. Ignored by the VRChat's camera unless 'UI' is enabled in the camera.                                                    |
+| 6            | reserved6           | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                          |
+| 7            | reserved7           | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                          |
 | 8            | Interactive         | Unused by Unity and VRChat.                                                                                                                                                                                                                                          |
 | 9            | Player              | Used for VRChat's players, except the local player.                                                                                                                                                                                                                  |
 | 10           | PlayerLocal         | Used by VRChat to render the local player. Humanoid avatars are rendered without their head bone.                                                                                                                                                                   |
@@ -35,7 +35,7 @@ When you create a Unity project with VRChat's Worlds SDK, your project will auto
 | 14           | PickupNoEnvironment | Colliders on this Layer only collide with 'Pickup.'                                                                                                                                                                                                                  |
 | 15           | StereoLeft          | Unused by Unity and VRChat. |
 | 16           | StereoRight         | Unused by Unity and VRChat.                                                                                                                                                                                                                                          |
-| 17           | Walkthrough          | Colliders on this layer do not collide with players. |
+| 17           | Walkthrough         | Colliders on this layer do not collide with players. |
 | 18           | MirrorReflection    | Used by VRChat to render the local player in Mirrors. <br />Renderers on this Layer will only appear in Mirrors. <br />Renderers on this Layer are not rendered in VRChat's main camera.<br /> Colliders on this Layer do not block VRChat's Raycasts.                                      |
 | 19           | InternalUI          | ⚠ Avoid using this layer. Used by VRChat for internal UI elements such as debug consoles. |
 | 20           | HardwareObjects     | ⚠ Avoid using this layer. Used by VRChat to render virtual representations of physical hardware in-game i.e. controllers and trackers |                                                                                                                       

--- a/Docs/docs/worlds/layers.md
+++ b/Docs/docs/worlds/layers.md
@@ -1,7 +1,7 @@
 ---
 title: "Unity Layers in VRChat"
 slug: "layers"
-excerpt: "What Unity Layers are used by VRChat and Untiy?"
+excerpt: "What Unity Layers are used by VRChat and Unity?"
 hidden: false
 createdAt: "2023-04-03T21:22:34.611Z"
 updatedAt: "2023-04-24T16:23:07.971Z"
@@ -16,31 +16,31 @@ Layers 22-31 are unused 'User' Unity layers. You can edit them freely, and chang
 
 ## Unity's built-in layers
 
-| Layer number | Layer Name          | Description  |
-|:-------------|:--------------------| :-- |
-| 0            | Default             | Used for Unity's Game Objects by default. Used by VRChat's Avatar Pedestals.                                                                                                                                                                                         |
-| 1            | TransparentFX       | Used for Unity's Flare Assets.                                                                                                                                                                                                                                       |
-| 2            | IgnoreRaycast       | Ignored by Unity's Physics Raycasts if no layer mask is provided. Not ignored by VRChat's Physics Raycasts.                                                                                                                                                         |
-| 3            | reserved3           | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                          |
-| 4            | Water               | Used by Unity's Standard Assets. Used by VRChat's Portals. Used by VRChat's Mirrors. Often used for Unity's Post Processing.                                                                                                                                          |
-| 5            | UI                  | ⚠ You may not want to use this layer. Used by Unity's UI by default. Ignored by VRChat's UI pointer unless the player has the VRChat menu open. Ignored by the VRChat's camera unless 'UI' is enabled in the camera.                                                    |
-| 6            | reserved6           | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                          |
-| 7            | reserved7           | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                          |
-| 8            | Interactive         | Unused by Unity and VRChat.                                                                                                                                                                                                                                          |
-| 9            | Player              | Used for VRChat's players, except the local player.                                                                                                                                                                                                                  |
-| 10           | PlayerLocal         | Used by VRChat to render the local player. Humanoid avatars are rendered without their head bone.                                                                                                                                                                   |
-| 11           | Environment         | Unused by Unity and VRChat.                                                                                                                                                                                                                                          |
-| 12           | UiMenu              | ⚠ Avoid using this layer. Used by VRChat's nameplates. Ignored by VRChat's UI pointer unless the player has the VRChat menu open.                                                                                                                                   |
-| 13           | Pickup              | Used by VRChat's Pickups by default when you add a pickup component. Does not collide with players.                                                                                                                                                                 |
-| 14           | PickupNoEnvironment | Colliders on this Layer only collide with 'Pickup.'                                                                                                                                                                                                                  |
-| 15           | StereoLeft          | Unused by Unity and VRChat. |
-| 16           | StereoRight         | Unused by Unity and VRChat.                                                                                                                                                                                                                                          |
-| 17           | Walkthrough         | Colliders on this layer do not collide with players. |
-| 18           | MirrorReflection    | Used by VRChat to render the local player in Mirrors. <br />Renderers on this Layer will only appear in Mirrors. <br />Renderers on this Layer are not rendered in VRChat's main camera.<br /> Colliders on this Layer do not block VRChat's Raycasts.                                      |
-| 19           | InternalUI          | ⚠ Avoid using this layer. Used by VRChat for internal UI elements such as debug consoles. |
-| 20           | HardwareObjects     | ⚠ Avoid using this layer. Used by VRChat to render virtual representations of physical hardware in-game i.e. controllers and trackers |                                                                                                                       
-| 21           | reserved4           |  ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default).                                                                                                                                                                                                                                                                    |
-| 22-31        |                     | Unused by Unity and VRChat. VRChat will not override the name and collision matrix of these Layers in uploaded worlds.                                                                                                                                               |
+| Layer Number | Layer Name | Description |
+| --- | --- | --- |
+| 0 | Default | Used for Unity's Game Objects by default. Used by VRChat's Avatar Pedestals. |
+| 1 | TransparentFX | Used for Unity's Flare Assets. |
+| 2 | IgnoreRaycast | Ignored by Unity's Physics Raycasts if no layer mask is provided. Not ignored by VRChat's Physics Raycasts. |
+| 3 | reserved3 | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default). |
+| 4 | Water | Used by Unity's Standard Assets. Used by VRChat's Portals. Used by VRChat's Mirrors. Often used for Unity's Post Processing. |
+| 5 | UI | ⚠ You may not want to use this layer. Used by Unity's UI by default. Ignored by VRChat's UI pointer unless the player has the VRChat menu open. Ignored by the VRChat's camera unless 'UI' is enabled in the camera. |
+| 6 | reserved6 | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default). |
+| 7 | reserved7 | ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default). |
+| 8 | Interactive | Unused by Unity and VRChat. |
+| 9 | Player | Used for VRChat's players, except the local player. |
+| 10 | PlayerLocal | Used by VRChat to render the local player. Humanoid avatars are rendered without their head bone. |
+| 11 | Environment | Unused by Unity and VRChat. <br />This layer shares the same collision matrix as `Default`. |
+| 12 | UiMenu | ⚠ Avoid using this layer. Used by VRChat's nameplates. Ignored by VRChat's UI pointer unless the player has the VRChat menu open. |
+| 13 | Pickup | Used by VRChat's Pickups by default when you add a pickup component. Does not collide with players.  |
+| 14 | PickupNoEnvironment | Colliders on this Layer only collide with `Pickup`. |
+| 15 | StereoLeft | Unused by Unity and VRChat. |
+| 16 | StereoRight | Unused by Unity and VRChat. |
+| 17 | Walkthrough | Colliders on this layer do not collide with players. |
+| 18 | MirrorReflection | Used by VRChat to render the local player in Mirrors. <br />Renderers on this Layer will only appear in Mirrors. <br />Renderers on this Layer are not rendered in VRChat's main camera.<br /> Colliders on this Layer do not block VRChat's Raycasts. |
+| 19 | InternalUI          | ⚠ Avoid using this layer. Used by VRChat for internal UI elements such as debug consoles. |
+| 20 | HardwareObjects     | ⚠ Avoid using this layer. Used by VRChat to render virtual representations of physical hardware in-game i.e. controllers and trackers |                                                                                                                       
+| 21 | reserved4           |  ⚠ Avoid using this layer. Reserved by VRChat. When you upload your world, any Game Object on a reserved Layer will be moved to Layer 0 (Default). |
+| 22-31 | | Unused by Unity and VRChat. VRChat will not override the name and collision matrix of these Layers in uploaded worlds. 
 
 ## Interaction Block and Passthrough on VRChat Layers
 

--- a/Docs/docs/worlds/udon/external-urls.md
+++ b/Docs/docs/worlds/udon/external-urls.md
@@ -1,0 +1,38 @@
+---
+title: "External URLs"
+slug: "external-urls"
+hidden: false
+createdAt: "2024-02-07T01:23:08.000Z"
+updatedAt: "2024-04-25T11:00:00.000Z"
+---
+
+# External URLs
+Udon can use external URLs to load remote content. URLs must be wrapped in a [VRCUrl](#vrcurl) object. Users can enter URLs into `VRCUrlInputField` components at runtime, and world creators can provide pre-defined VRCUrls with their uploaded worlds.
+
+## Allowlist
+For security reasons, VRChat restricts how external URLs can be used. By default, a [VRCUrl](#vrcurl) can only be accessed if it is on VRChat's domain allowlist.
+If a URL is **not** on the required allowlist for its type, it cannot be used unless the user chooses to "Allow Untrusted URLs" in VRChat's settings. This allows Udon to use load untrusted URL from `VRCUrlInputField` components and any `VRCUrl` that was uploaded alongside the world.
+
+|                                           | On allowlist | Not on allowlist                   |
+| ----                                      | ----         | ----                               |
+| User enters `VRCUrl` into input field     | ✔Allowed     | ⚠ Requires "Allow Untrusted URLs" |
+| Udon declares the `VRCUrl` before runtime | ✔Allowed     | ⚠ Requires "Allow Untrusted URLs" |
+
+## VRCUrl
+`class VRC.SDKBase.VRCUrl`
+
+### Constructor
+| Name | Summary |
+| --- | --- |
+| VRCUrl(string url) | Constructor that takes a URL as input.  Note that this can only be called at *editor time*. |
+
+### Properties
+| Static | Type | Name | Summary |
+| :---: | --- | --- | --- |
+| ✔️ | [VRCUrl](#vrcurl) | Empty | An empty URL. |
+
+### Methods
+| Static | Returns | Name | Summary |
+| :---: | --- | --- | --- |
+|| string | Get() | Retrieves the current string value of the URL. |
+| ✔️ | bool | IsNullOrEmpty([VRCUrl](#vrcurl) vrcUrl) | Indicates whether the specified [VRCUrl](#vrcurl) is null or referencing an empty string (""). |

--- a/Docs/releases/release-3.5.3.md
+++ b/Docs/releases/release-3.5.3.md
@@ -1,0 +1,54 @@
+---
+slug: release-3-5-3
+date: 2024-04-11
+title: Release 3.5.3 Beta
+authors: [momo]
+tags: [release]
+---
+## Summary
+
+This release overhauls the World SDK UI, exposes new Udon functions, and fixes some issues across the SDK and ClientSim.
+
+Superceded by [version 3.6.0](/releases/release-3-6-0). Version 3.5.3 entered beta testing but was not launched officially.
+<!--truncate-->
+
+## New features
+
+- Big updates to the Worlds SDK for creators! This is a major update with a lot of additions including:
+    - A rewrite of all almost all custom inspectors in the World's SDK.
+    - Updated HelpURLs (the question mark on a component) to *actually* taking you to the VRC docs (gasp).
+    - Properly added almost 20 components to the **Add Component -> VRChat** section.
+    - The Two-Factor Authentication field in the SDK automatically submits once you enter six digits, instead of requiring you to press the Verify button.
+- World creators now have the ability to modify the value of `UnityEngine.Physics.bounceThreshold` via Udon. Addresses [this Canny request](https://feedback.vrchat.com/feature-requests/p/allow-world-creators-to-change-physics-settings).
+    - This allows world creators to have better control over when objects should or shouldn't bounce, which can be important for physics-based worlds.
+
+## Changes
+
+- Layers 3, 6, and 7 are now reserved layers for VRChat. Previously, these were internally reserved by Unity and were freed up in Unity 2022.
+    - VRChat now reserves them for internal use moving forward and will move any objects in this layer to the default layer. Reflected [here](/worlds/layers/#unitys-built-in-layers) in our creator docs.
+
+## Fixes
+
+- Fixed the broken Standard Lite shader **Emission** feature.
+- Fixed an error about failing to assign network IDs when trying to upload the default VRC world scene right after initialization.
+- Fixed Unity warning when using the sample dynamic Robot Avatar from the VRChat Avatars SDK.
+- Exposed missing string methods to Udon. Addresses [this Canny request](https://feedback.vrchat.com/sdk-bug-reports/p/350-beta1-stringtrim-stringtrimstart-and-stringtrimend-are-not-exposed-to-udon-i).
+    - Certain variants of `Trim`, `TrimStart`, `TrimEnd`, and others were previously available in Unity 2019 but caused compilation issues in Unity 2022. This fixes those regressions.
+
+## ClientSim
+
+- Fixed joystick drift issues by adding input axis deadzones. Addresses [this GitHub issue](https://github.com/vrchat-community/ClientSim/issues/1).
+- Updated ClientSim to use IETF language codes instead of full language names to more accurately simulate VRChat's behavior.
+
+## Public API Changes
+
+- SDK methods from `ShaderValidation` have been moved into the `ValidationUtils` class.
+- Method signatures from `ValidationUtils` have been modified. **Anyone using these methods may need to update their code!**
+
+## Known Issues
+
+- The first time you open a Scene and select a GameObject inside a prefab with a U# Behaviour, the GUI for the component directly below that U# Behaviour will not show its GUI. Deselecting and re-selecting the prefab fixes this.
+- Buffer Particles don't work as they did in Unity 2019, [there is a workaround to fix them from community member hfcRed here](https://x.com/hfcRedddd/status/1696915379090604179).
+- The Editor may crash when updating a shader graph reference by another shader using UsePass. This is an issue with Unity 2022.3.6f1 and is fixed in 2022.3.14f1.
+- Unity 2022 sometimes causes Rider's debugger to stop for unhandled exceptions in Unity's IMGUI.
+    - Please refer to [this workaround](https://forum.unity.com/threads/rider-debugger-breaks-on-unhandled-exception.1135879/#post-7305256) and [Jetbrains's bug tracker](https://youtrack.jetbrains.com/issue/RIDER-64944) for more information.

--- a/Docs/releases/release-3.6.0.md
+++ b/Docs/releases/release-3.6.0.md
@@ -1,0 +1,68 @@
+---
+slug: release-3-6-0
+date: 2024-04-26
+title: Release 3.6.0
+authors: [momo]
+tags: [release]
+---
+## Summary
+
+This release overhauls the World SDK UI, exposes new Udon functions, and fixes some issues across the SDK and ClientSim.
+
+Supercedes [release 3.5.3](/releases/release-3-5-3), which was available for beta testing but was not launched officially.
+
+<!--truncate-->
+
+## New features
+
+- Big updates to the Worlds SDK for creators! This is a major update with a lot of additions including:
+    - A rewrite of all almost all custom inspectors in the World's SDK.
+    - Updated HelpURLs (the question mark on a component) to *actually* taking you to the VRC docs (gasp).
+    - Properly added almost 20 components to the **Add Component -> VRChat** section.
+    - The Two-Factor Authentication field in the SDK automatically submits once you enter six digits, instead of requiring you to press the Verify button.
+- World creators now have the ability to modify the value of `UnityEngine.Physics.bounceThreshold` via Udon. Addresses [this Canny request](https://feedback.vrchat.com/feature-requests/p/allow-world-creators-to-change-physics-settings).
+    - This allows world creators to have better control over when objects should or shouldn't bounce, which can be important for physics-based worlds.
+
+## Changes
+
+- Layers 3, 6, and 7 are now reserved layers for VRChat. Previously, these were internally reserved by Unity and were freed up in Unity 2022.
+    - VRChat now reserves them for internal use moving forward and will move any objects in this layer to the default layer. Reflected [here](/worlds/layers/#unitys-built-in-layers) in our creator docs.
+
+## Fixes
+
+- Fixed the broken Standard Lite shader **Emission** feature.
+- Fixed an error about failing to assign network IDs when trying to upload the default VRC world scene right after initialization.
+- Fixed Unity warning when using the sample dynamic Robot Avatar from the VRChat Avatars SDK.
+- Exposed missing string methods to Udon. Addresses [this Canny request](https://feedback.vrchat.com/sdk-bug-reports/p/350-beta1-stringtrim-stringtrimstart-and-stringtrimend-are-not-exposed-to-udon-i).
+    - Certain variants of `Trim`, `TrimStart`, `TrimEnd`, and others were previously available in Unity 2019 but caused compilation issues in Unity 2022. This fixes those regressions.
+
+## ClientSim
+
+- Fixed joystick drift issues by adding input axis deadzones. Addresses [this GitHub issue](https://github.com/vrchat-community/ClientSim/issues/1).
+- Updated ClientSim to use IETF language codes instead of full language names to more accurately simulate VRChat's behavior.
+
+## Public API Changes
+
+- SDK methods from `ShaderValidation` have been moved into the `ValidationUtils` class.
+- Method signatures from `ValidationUtils` have been modified. **Anyone using these methods may need to update their code!**
+
+## Fixes between 3.5.3-beta.2 and 3.6.0-beta.1
+
+- ClientSim input axis dead zones would make mouse movement awkwardly slow.
+- World upload could fail with an `AmbiguousMatchException` when a scene contained components with multiple `RequireComponent` attributes.
+- Calling `Instantiate` from Udon in certain events like `OnPlayerJoined` could fail in ClientSim.
+- Pickups would not work in ClientSim.
+- Canvas UI with `VRC_UiShape` components would not be interactable in ClientSim.
+- `VRC_ObjectSync` and `VRC_ObjectPool` would fail to initialize in ClientSim.
+
+## Fixes between 3.6.0-beta.1 and final release
+
+- Fixed an issue that could cause editor crashes with a memory allocation warning under rare circumstances.
+
+## Known Issues
+
+- The first time you open a Scene and select a GameObject inside a prefab with a U# Behaviour, the GUI for the component directly below that U# Behaviour will not show its GUI. Deselecting and re-selecting the prefab fixes this.
+- Buffer Particles don't work as they did in Unity 2019, [there is a workaround to fix them from community member hfcRed here](https://x.com/hfcRedddd/status/1696915379090604179).
+- The Editor may crash when updating a shader graph reference by another shader using UsePass. This is an issue with Unity 2022.3.6f1 and is fixed in 2022.3.14f1.
+- Unity 2022 sometimes causes Rider's debugger to stop for unhandled exceptions in Unity's IMGUI.
+    - Please refer to [this workaround](https://forum.unity.com/threads/rider-debugger-breaks-on-unhandled-exception.1135879/#post-7305256) and [Jetbrains's bug tracker](https://youtrack.jetbrains.com/issue/RIDER-64944) for more information.


### PR DESCRIPTION
This is just a minor change that adds a few improvements to the World Creation Documentation.

- Added Tip to `vrc_mirrorreflection.md` regarding Reflect Layers.
   - This was added because there is literally no source of information on what a Creator should set for the `Reflect Layers`. So I believe it is better if we give a bit more context about telling the reader how to decide setting the `Reflect Layers` in a Mirror, for performance reasons.
- Added Note on the `Environment` layer in `layers.md`.
   - I added a note regarding that it shares the same collision matrix with `Default`, which I think is good to mention.
- Fixed unnecessary spacing on the Table in `layers.md`. Docusaurus handles the spacing automatically.
- Fixed caught typo in the markdown `excerpt:` line in `layers.md`.

Do keep in mind that this was built up from commit `8b3a17b5893752bd9985bfd5c612f7fe1d870a25`, which synced from the Upstream Repo by Momo. So I made sure that all recent information added by Momo are still in here.