### PR TITLE
Unity quest content description

### DIFF
--- a/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
+++ b/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
@@ -8,12 +8,6 @@ sidebar_position: -1
 ---
 ![Building for Mobile instructions](/img/setting-up-unity-for-creating-quest-content-1ac8b19-VRChat_QuestContent_QuickStart.png)
 
-:::caution Requires Additional Setup
-
-[You need to install Unity's Android SDK](https://docs.unity3d.com/2019.4/Documentation/Manual/android-sdksetup.html). Otherwise, the option won't pop up.
-
-:::
-
 If you're starting a brand new project, this won't take long at all. However, if you're converting a Windows platform project to an Android platform project, you will have to convert your assets appropriately. This can take quite a while for larger projects.
 
 For more details on best practices when working with dual-platform projects, read our documentation on [Cross-Platform Setup](/platforms/android/cross-platform-setup).
@@ -28,7 +22,12 @@ Pros use the hotkeys Ctrl + Shift + B.
 
 ### 2. Switch Platform to Android
 
-Click "Android" -> "Switch Platform". Unity will automatically convert assets for Android-ready, it will take a while for larger projects with lots of assets. **If Android isn't appearing: [you'll need to install it.](https://docs.unity3d.com/Manual/android-sdksetup.html)**
+:::caution Requires Additional Setup
+If the Android option isn't appearing, [you'll need to install Unity's Android SDK.](https://docs.unity3d.com/Manual/android-sdksetup.html)
+
+:::
+
+Click "Android" -> "Switch Platform". Unity will automatically convert assets for Android-ready, it will take a while for larger projects with lots of assets.
 
 ### 3. Publish -> New Build
 

--- a/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
+++ b/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
@@ -29,4 +29,4 @@ Click "Android" -> "Switch Platform". Unity will automatically convert assets fo
 
 ### 3. Publish -> New Build
 
-That's it! Your content is ready to check out on the Quest! Note that **you must publish**. Testing locally is not supported for Quest.
+That's it! Your content is now available on Quest! Note that you must **upload** your content to test it. You can't use the SDK's "Build and Test" feature for Android content.

--- a/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
+++ b/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
@@ -21,11 +21,11 @@ You can access your [Build Settings](https://docs.unity3d.com/Manual/BuildSettin
 ### 2. Switch Platform to Android
 
 :::caution Requires Additional Setup
-If the Android option isn't appearing, [you'll need to install Unity's Android SDK.](https://docs.unity3d.com/Manual/android-sdksetup.html)
+If the Android option isn't appearing, [you need to install Unity's Android SDK.](https://docs.unity3d.com/Manual/android-sdksetup.html)
 
 :::
 
-Click "Android" -> "Switch Platform". Unity will automatically convert assets for Android-ready, it will take a while for larger projects with lots of assets.
+Click "Android" -> "Switch Platform". Unity will reimport your assets for Android. This will take a while for larger projects with many assets.
 
 ### 3. Publish -> New Build
 

--- a/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
+++ b/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
@@ -12,7 +12,7 @@ If you're starting a brand new project, this won't take long at all. However, if
 
 For more details on best practices when working with dual-platform projects, read our documentation on [Cross-Platform Setup](/platforms/android/cross-platform-setup).
 
-## 3 Steps to get your world on VRChat for Oculus Quest
+## 3 Steps to get your world on VRChat for Quest
 
 ### 1. Open Your Build Settings
 

--- a/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
+++ b/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
@@ -6,14 +6,30 @@ createdAt: "2019-04-10T00:53:35.417Z"
 updatedAt: "2019-10-28T19:23:09.636Z"
 sidebar_position: -1
 ---
-Setting up Unity to create Quest content is actually pretty straightforward. This image covers it pretty well:
-![setting-up-unity-for-creating-quest-content-1ac8b19-VRChat_QuestContent_QuickStart.png](/img/setting-up-unity-for-creating-quest-content-1ac8b19-VRChat_QuestContent_QuickStart.png)
+![Building for Mobile instructions](/img/setting-up-unity-for-creating-quest-content-1ac8b19-VRChat_QuestContent_QuickStart.png)
 
 :::caution Requires Additional Setup
 
-[You need to install Unity's Android SDK](https://docs.unity3d.com/2019.4/Documentation/Manual/android-sdksetup.html). Otherwise the option won't pop up.
+[You need to install Unity's Android SDK](https://docs.unity3d.com/2019.4/Documentation/Manual/android-sdksetup.html). Otherwise, the option won't pop up.
 
 :::
+
 If you're starting a brand new project, this won't take long at all. However, if you're converting a Windows platform project to an Android platform project, you will have to convert your assets appropriately. This can take quite a while for larger projects.
 
 For more details on best practices when working with dual-platform projects, read our documentation on [Cross-Platform Setup](/platforms/android/cross-platform-setup).
+
+## 3 Steps to get your world on VRChat for Oculus Quest
+
+### 1. Open Your Build Settings
+
+:::tip 
+Pros use the hotkeys Ctrl + Shift + B.
+:::
+
+### 2. Switch Platform to Android
+
+Click "Android" -> "Switch Platform". Unity will automatically convert assets for Android-ready, it will take a while for larger projects with lots of assets. **If Android isn't appearing: [you'll need to install it.](https://docs.unity3d.com/Manual/android-sdksetup.html)**
+
+### 3. Publish -> New Build
+
+That's it! Your content is ready to check out on the Quest! Note that **you must publish**. Testing locally is not supported for Quest.

--- a/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
+++ b/Docs/docs/platforms/android/setting-up-unity-for-creating-quest-content.md
@@ -16,9 +16,7 @@ For more details on best practices when working with dual-platform projects, rea
 
 ### 1. Open Your Build Settings
 
-:::tip 
-Pros use the hotkeys Ctrl + Shift + B.
-:::
+You can access your [Build Settings](https://docs.unity3d.com/Manual/BuildSettings.html) from Unity's main menu by going to "File" -> "Build Settings". Or you can use the keyboard shortcut `Ctrl` + `Shift` + `B`.
 
 ### 2. Switch Platform to Android
 


### PR DESCRIPTION
Adds a description for Android build instructions from the explainer image to the article, making the article easier to read (and embedding a link that was initially only embedded in the image). Increases accessibility of the article to screenreaders and other technologies with a long description of what is going on in the image.