### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please read [Contribution guide](https://creators.vrchat.com/contribute/) before contribution!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please read [Contribution guide](https://creators.vrchat.com/contribute/) before contribution!
+Please read the [contribution guide](https://creators.vrchat.com/contribute/) before contributing to the VRChat Creation documentation.


### PR DESCRIPTION
Recently contributing guide for creator docs is added to creators.vrchat.com but it will not be recognized by GitHub so GitHub does not suggest for reading contribution guide.
This PR adds `CONTRIBUTING.md` that refers contributing guide that GitHub recognizes.