### PR TITLE
remove cdn.discordapp.com from image-loading.md

### DIFF
--- a/Docs/docs/worlds/udon/image-loading.md
+++ b/Docs/docs/worlds/udon/image-loading.md
@@ -29,7 +29,6 @@ There are a few Image Loader limits and parameters you should know:
 
 And only certain domains are allowed. If a domain is not on the list, images will not download unless **Allow Untrusted URLs** has been enabled in the user's settings.
 
-- Discord (`cdn.discordapp.com`)
 - Dropbox (`dl.dropbox.com`)
 - GitHub (`*.github.io`)
 - ImageBam (`images4.imagebam.com`)


### PR DESCRIPTION
Removing cdn.discordapp.com from the image-loading docs.