### PR TITLE
Update iOS documentation by removing beta warning

### DIFF
--- a/Docs/docs/platforms/iOS/index.md
+++ b/Docs/docs/platforms/iOS/index.md
@@ -1,9 +1,5 @@
 # iOS
 
-:::warning
-VRChat on iOS is currently in Beta. Please report issues on [Canny](https://feedback.vrchat.com/ios-mobile-beta). (Your VRChat account must have a trust rank of "New User" or higher.)
-:::
-
 This section contains helpful pages on creating VRChat Worlds and Avatars for iOS devices.
 
 Guidelines that refer to "Android" or "Quest" apply to iOS, too. Use these guides to learn more about optimization and best practices.


### PR DESCRIPTION
Removed beta warning for VRChat on iOS due to its being released: https://hello.vrchat.com/blog/vrchat-mobile-release